### PR TITLE
Added defines to allow compilation with DCW and ECDH OFF.

### DIFF
--- a/frontend/fileBasedPSI.cpp
+++ b/frontend/fileBasedPSI.cpp
@@ -271,6 +271,7 @@ void doFilePSI(const CLP& cmd)
 		}
 		else if (cmd.isSet("ecdh"))
 		{
+#ifdef ENABLE_ECDH_PSI
 			padSmallSet(set, theirSize, cmd);
 
 			if (r == Role::Sender)
@@ -286,6 +287,9 @@ void doFilePSI(const CLP& cmd)
 				recver.sendInput(set, span<Channel>{&chl, 1});
 				writeOutput(outPath, ft, recver.mIntersection);
 			}
+#else
+            throw std::runtime_error("ECDH not enabled.");
+#endif
 		}
 		//else if (cmd.isSet("dkt"))
 		//{

--- a/libPSI_Tests/DcwBfPsi_Tests.cpp
+++ b/libPSI_Tests/DcwBfPsi_Tests.cpp
@@ -225,4 +225,19 @@ void DcwRBfPsi_SingltonSet_Test_Impl()
     recvThrd.join();
 
 }
-#endif 
+#else
+
+void DcwRBfPsi_EmptrySet_Test_Impl()
+{
+    throw UnitTestSkipped("not enabled");
+}
+void DcwRBfPsi_FullSet_Test_Impl()
+{
+    throw UnitTestSkipped("not enabled");
+}
+void DcwRBfPsi_SingltonSet_Test_Impl()
+{
+    throw UnitTestSkipped("not enabled");
+}
+
+#endif


### PR DESCRIPTION
Without the added preprocessor directives, it is not possible to compile the library with `-DENABLE_DCW_PSI=OFF` or `-DENABLE_ECDH_PSI=OFF`.