### PR TITLE
Add WOLFSSL to cmake to enable compilation with wolfssl.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,9 @@ include_directories("${Miracl_Dirs}")
 # default location for Boost
 set(BOOST_ROOT "${libOTe_Dirs}/cryptoTools/thirdparty/linux/boost/")
 
+# default location for Wolfssl
+set(WolfSSL_DIR "/usr/local/")
+
 
 #############################################
 #                CONFIGURE                  #
@@ -104,6 +107,7 @@ option(ENABLE_MIRACL     "use the miracl library" OFF)
 option(ENABLE_RELIC      "use the relic library" OFF)
 option(ENABLE_SIMPLESTOT "use the simplest OT library" OFF)
 option(ENABLE_MR_KYBER   "use the kyber OT library" OFF)
+option(ENABLE_WOLFSSL     "use the wolfssl library" OFF)
 
 message(STATUS "General Options\n=======================================================")
 message(STATUS "Option: CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}\n\tRelease\n\tDebug\n\tRELWITHDEBINFO")
@@ -125,7 +129,8 @@ message(STATUS "libOTe & cryptoTools options\n==================================
 message(STATUS "Option: ENABLE_MIRACL     = ${ENABLE_MIRACL}")
 message(STATUS "Option: ENABLE_RELIC      = ${ENABLE_RELIC}")
 message(STATUS "Option: ENABLE_SIMPLESTOT = ${ENABLE_SIMPLESTOT}")
-message(STATUS "Option: ENABLE_MR_KYBER   = ${ENABLE_MR_KYBER}\n\n")
+message(STATUS "Option: ENABLE_MR_KYBER   = ${ENABLE_MR_KYBER}")
+message(STATUS "Option: ENABLE_WOLFSSL     = ${ENABLE_WOLFSSL}\n\n")
 
 configure_file(libPSI/config.h.in libPSI/config.h)
 

--- a/libPSI/CMakeLists.txt
+++ b/libPSI/CMakeLists.txt
@@ -141,3 +141,28 @@ if (ENABLE_RELIC)
 
 endif (ENABLE_RELIC)
 
+## WolfSSL
+###########################################################################
+
+if(ENABLE_WOLFSSL)
+
+    if(NOT DEFINED WolfSSL_DIR)
+        set(WolfSSL_DIR "/usr/local/")
+    endif()
+
+
+    find_library(WOLFSSL_LIB NAMES wolfssl  HINTS "${WolfSSL_DIR}")
+    set(WOLFSSL_LIB_INCLUDE_DIRS "${WolfSSL_DIR}include/")
+
+    # if we cant fint it, throw an error
+    if(NOT WOLFSSL_LIB)
+        message(FATAL_ERROR "Failed to find WolfSSL at " ${WolfSSL_DIR})
+    endif()
+
+    message(STATUS "WOLFSSL_LIB:  ${WOLFSSL_LIB}")
+    message(STATUS "WOLFSSL_INC:  ${WOLFSSL_LIB_INCLUDE_DIRS}\n")
+
+    target_include_directories(libPSI PUBLIC "${WOLFSSL_LIB_INCLUDE_DIRS}")
+    target_link_libraries(libPSI ${WOLFSSL_LIB})
+
+endif(ENABLE_WOLFSSL)


### PR DESCRIPTION
I added wolfssl to the CMakeLists.txt because otherwise I got an linker error, if I compiled libOTe/cryptoTools with wolfssl but libPSI without.
Now, Wolfssl can be enabled with `-DENABLE_WOLFSSL=ON` as in libOTe.