### PR TITLE
trivial bug in Rr17a protocol

### DIFF
--- a/libPSI/MPSI/Rr17/Rr17a/Rr17aMPsiReceiver.cpp
+++ b/libPSI/MPSI/Rr17/Rr17a/Rr17aMPsiReceiver.cpp
@@ -569,7 +569,7 @@ namespace osuCrypto
 
                 u64 numMasks = mN * mBins.mMaxBinSize;
                 u64 chunkSize = std::min<u64>(1 << 20, (numMasks + chls.size() - 1) / chls.size());
-                u64 numChunks = numMasks / chunkSize;
+                u64 numChunks = (numMasks + (chunkSize - 1)) / chunkSize;
 
 
                 //std::array<block, 32> tempMaskBuff;

--- a/libPSI/MPSI/Rr17/Rr17a/Rr17aMPsiReceiver.cpp
+++ b/libPSI/MPSI/Rr17/Rr17a/Rr17aMPsiReceiver.cpp
@@ -475,7 +475,7 @@ namespace osuCrypto
                 auto insertEnd = insertBuffer.data() + insertBuffer.size();
 
 
-                auto keySize = std::min<u64>(sizeof(u64), maskSize);                
+                auto keySize = std::min<u64>(sizeof(u64), maskSize);
                 u64 keyMask = (~0ull) >> ((sizeof(u64) - keySize) * 8);
                 std::unordered_map<u64, std::pair<i64, block>> maskMap;maskMap.reserve(mN * mBins.mMaxBinSize);
 

--- a/libPSI/MPSI/Rr17/Rr17a/Rr17aMPsiReceiver.cpp
+++ b/libPSI/MPSI/Rr17/Rr17a/Rr17aMPsiReceiver.cpp
@@ -475,8 +475,8 @@ namespace osuCrypto
                 auto insertEnd = insertBuffer.data() + insertBuffer.size();
 
 
-                auto keySize = std::min<u64>(sizeof(u64), maskSize);
-                u64 keyMask = (1ull << (keySize * 8)) - 1;// (~0ull) >> ((sizeof(u64) - keySize) * 8);
+                auto keySize = std::min<u64>(sizeof(u64), maskSize);                
+                u64 keyMask = (~0ull) >> ((sizeof(u64) - keySize) * 8);
                 std::unordered_map<u64, std::pair<i64, block>> maskMap;maskMap.reserve(mN * mBins.mMaxBinSize);
 
                 for (u64 bIdx = binStart; bIdx < binEnd;)

--- a/libPSI/MPSI/Rr17/Rr17a/Rr17aMPsiSender.cpp
+++ b/libPSI/MPSI/Rr17/Rr17a/Rr17aMPsiSender.cpp
@@ -312,7 +312,7 @@ namespace osuCrypto
         auto maskView = MatrixView<u8>(sendMaskBuff->begin(), sendMaskBuff->end(), maskSize);
 
         u64 masksPer = std::min<u64>(1 << 20, (numMasks + chls.size() - 1) / chls.size());
-        u64 numChunks = numMasks / masksPer;
+        u64 numChunks = (numMasks + (masksPer - 1)) / masksPer;
         auto sendMaskBuffFreeCounter = new std::atomic<u32>;
         *sendMaskBuffFreeCounter = u32(numChunks);
 


### PR DESCRIPTION
When I executed Rr17a Protocol, the results looked wrong.
I found 2 trivial bugs. (But they possibly related to performance evaluation.)

1.
```
u64 numChunks = numMasks / chunkSize;
```
`numChunks` should be +1 when Indivisible.

2. 
```
u64 keyMask = (1ull << (keySize * 8)) - 1;
```
If `keySize` equals to `8` C++ may execute undefined something, at least in my environment Ubuntu 16.
The reversed code looks safe to me.